### PR TITLE
CHORE: Change 'com.querydsl' to 'io.github.openfeign.querydsl'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.10</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.percent99</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-    <querydsl.version>5.0.0</querydsl.version>
+    <openfeign.querydsl.version>7.1</openfeign.querydsl.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -114,17 +114,17 @@
 
     <!-- Querydsl -->
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>${querydsl.version}</version>
+      <version>${openfeign.querydsl.version}</version>
       <scope>provided</scope>
-      <classifier>jakarta</classifier>
+      <classifier>jpa</classifier>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
-      <version>${querydsl.version}</version>
-      <classifier>jakarta</classifier>
+      <version>${openfeign.querydsl.version}</version>
+      <scope>compile</scope>
     </dependency>
 
     <!-- AOP -->
@@ -145,6 +145,12 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 						</path>
+            <path>
+              <groupId>io.github.openfeign.querydsl</groupId>
+              <artifactId>querydsl-apt</artifactId>
+              <version>${openfeign.querydsl.version}</version>
+              <classifier>jpa</classifier>
+            </path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
@@ -169,23 +175,6 @@
                     </argLine>
                 </configuration>
             </plugin>
-
-      <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>apt-maven-plugin</artifactId>
-        <version>1.1.3</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/generated-sources/java</outputDirectory>
-              <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
CVE-2024-49203 취약점 보완을 위해 'com.querydsl' 의존성을 'io.github.openfeign.querydsl'로 변경