### PR TITLE
Refactoring: Seperate validate logic from aspect 'IsParticipant'

### DIFF
--- a/src/main/java/com/percent99/OutSpecs/aspect/ChatRoomAuthorizationAspect.java
+++ b/src/main/java/com/percent99/OutSpecs/aspect/ChatRoomAuthorizationAspect.java
@@ -1,56 +1,51 @@
 package com.percent99.OutSpecs.aspect;
 
 import com.percent99.OutSpecs.annotation.IsParticipant;
-import com.percent99.OutSpecs.repository.ChatRoomRepository;
+import com.percent99.OutSpecs.validator.ChatValidator;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.security.access.AccessDeniedException;
+import org.aspectj.lang.reflect.CodeSignature;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @Aspect
 @RequiredArgsConstructor
 public class ChatRoomAuthorizationAspect {
-  private final ChatRoomRepository chatRoomRepository;
-
-  private final ParameterNameDiscoverer parameterNameDiscoverer;
-  private final ExpressionParser parser;
+  private final ChatValidator chatValidator;
 
   @Before("@annotation(isParticipant)")
   public void checkParticipant(JoinPoint joinPoint, IsParticipant isParticipant){
-    MethodSignature signature = (MethodSignature)joinPoint.getSignature();
-    Method method = signature.getMethod();
-
+    CodeSignature signature = (CodeSignature) joinPoint.getSignature();
+    String[] paramNames = signature.getParameterNames();
     Object[] args = joinPoint.getArgs();
-    String[] parameterNames = parameterNameDiscoverer.getParameterNames(method);
 
-    if (parameterNames == null){
+    if (paramNames == null){
       throw new IllegalStateException("Parameter names must be available for AOP.");
     }
 
-    EvaluationContext context = new StandardEvaluationContext();
-    for (int i=0; i<parameterNames.length; ++i){
-      context.setVariable(parameterNames[i], args[i]);
+//    EvaluationContext context = new StandardEvaluationContext();
+//    for (int i=0; i<parameterNames.length; ++i){
+//      context.setVariable(parameterNames[i], args[i]);
+//    }
+
+//    Long chatRoomId = parser.parseExpression("#" + isParticipant.chatRoomIdArg())
+//            .getValue(context, Long.class);
+//    Long userId = parser.parseExpression("#" + isParticipant.userIdArg())
+//            .getValue(context, Long.class);
+
+    Map<String, Object> argMap = new HashMap<>();
+    for (int i=0; i<paramNames.length; ++i){
+      argMap.put(paramNames[i], args[i]);
     }
 
-    Long chatRoomId = parser.parseExpression("#" + isParticipant.chatRoomIdArg())
-            .getValue(context, Long.class);
-    Long userId = parser.parseExpression("#" + isParticipant.userIdArg())
-            .getValue(context, Long.class);
+    long chatroomId = (long)argMap.get(isParticipant.chatRoomIdArg());
+    long userId = (long)argMap.get(isParticipant.userIdArg());
 
-    boolean result = chatRoomRepository.existsByIdAndUserId(chatRoomId, userId);
-
-    if (!result){
-      throw new AccessDeniedException("User is not a participant in the chatroom.");
-    }
+    chatValidator.validateParticipant(chatroomId, userId);
   }
 }

--- a/src/main/java/com/percent99/OutSpecs/validator/ChatValidator.java
+++ b/src/main/java/com/percent99/OutSpecs/validator/ChatValidator.java
@@ -1,0 +1,18 @@
+package com.percent99.OutSpecs.validator;
+
+import com.percent99.OutSpecs.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatValidator {
+  private final ChatRoomRepository chatRoomRepository;
+
+  public void validateParticipant(long chatroomId, long userId){
+    boolean result = chatRoomRepository.existsByIdAndUserId(chatroomId, userId);
+
+    if (!result) throw new AccessDeniedException("User is not a participant in the chatroom.");
+  }
+}


### PR DESCRIPTION
* 요약: IsParticipant aspect에서 검증 로직을 별도의 validator로 분리

* 내용
  * AOP는 객체를 호출할 때 프록시를 대신 호출하고 aspect 동작(before, around 등)을 실행한 후 realObject를 호출함
  * 그러나 같은 객체 내의 메소드를 호출하는 self-invocation엔 프록시 객체가 아닌 realObject의 메소드를 호출하므로 당연히 aspect의 동작이 실행되지 않음 
    * `@Transactional`도 같은 서비스 내에서의 메소드에선 실행되지 않는다는게 이런 원리에서 였음. 그래서 같은 객체 내에서 IsParticipant 로직이 필요한 경우 객체 내의 private 메소드로 같은 동작을 구현할 수도 있음 
  * 하지만 이 방법은 동일 로직을 여러 위치에서 구현하는 것이고, 추후 검증 로직에 변경이 필요해 aspect의 로직을 변경하더라도 private 검증 로직을 깜빡해서 변경하지 않고 넘길 수 있음
  * 그래서 aspect와 내부 검증이 공통적으로 사용할 validator 클래스를 만들고, 둘 모두 validator의 검증 메소드를 사용하게 함.
  * 이러면 나중에 검증 로직의 변경이 생겨도 validator의 메소드를 수정하면 aspect와 서비스 내부 검증 로직 모두 반영됨.