### PR TITLE
Refactoring: Get parameter name and argument values from CodeSignature

### DIFF
--- a/src/main/java/com/percent99/OutSpecs/aspect/ChatMessageAuthorizationAspect.java
+++ b/src/main/java/com/percent99/OutSpecs/aspect/ChatMessageAuthorizationAspect.java
@@ -6,15 +6,12 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.aspectj.lang.reflect.CodeSignature;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @Aspect
@@ -22,30 +19,24 @@ import java.lang.reflect.Method;
 public class ChatMessageAuthorizationAspect {
   private final ChatMessageRepository chatMessageRepository;
 
-  private final ParameterNameDiscoverer parameterNameDiscoverer;
-  private final ExpressionParser parser;
-
   @Before("@annotation(isChatMessageSender)")
   public void checkSender(JoinPoint joinPoint, IsChatMessageSender isChatMessageSender){
-    MethodSignature signature = (MethodSignature)joinPoint.getSignature();
-    Method method = signature.getMethod();
+    CodeSignature signature = (CodeSignature)joinPoint.getSignature();
 
     Object[] args = joinPoint.getArgs();
-    String[] parameterNames = parameterNameDiscoverer.getParameterNames(method);
+    String[] paramNames = signature.getParameterNames();
 
-    if (parameterNames == null){
+    if (paramNames == null){
       throw new IllegalStateException("Parameter names must be available for AOP.");
     }
 
-    EvaluationContext context = new StandardEvaluationContext();
-    for (int i=0; i<parameterNames.length; ++i){
-      context.setVariable(parameterNames[i], args[i]);
+    Map<String, Object> argMap = new HashMap<>();
+    for (int i=0; i<paramNames.length; ++i){
+      argMap.put(paramNames[i], args[i]);
     }
 
-    Long chatMessageId = parser.parseExpression("#" + isChatMessageSender.chatMessageIdArg())
-            .getValue(context, Long.class);
-    Long userId = parser.parseExpression("#" + isChatMessageSender.userIdArg())
-            .getValue(context, Long.class);
+    Long chatMessageId = (Long)argMap.get(isChatMessageSender.chatMessageIdArg());
+    Long userId = (Long)argMap.get(isChatMessageSender.userIdArg());
 
     boolean result = chatMessageRepository.existsByIdAndUserId(chatMessageId, userId);
 

--- a/src/main/java/com/percent99/OutSpecs/aspect/ProfileValidationAspect.java
+++ b/src/main/java/com/percent99/OutSpecs/aspect/ProfileValidationAspect.java
@@ -7,14 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.aspectj.lang.reflect.CodeSignature;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 @Aspect
 @Component
@@ -22,28 +19,22 @@ import java.lang.reflect.Method;
 public class ProfileValidationAspect {
   private final ProfileRepository profileRepository;
 
-  private final ParameterNameDiscoverer parameterNameDiscoverer;
-  private final ExpressionParser parser;
-
   @Before("@annotation(hasProfile)")
   public void checkProfile(JoinPoint joinPoint, HasProfile hasProfile){
-    MethodSignature signature = (MethodSignature)joinPoint.getSignature();
-    Method method = signature.getMethod();
-
+    CodeSignature signature = (CodeSignature)joinPoint.getSignature();
     Object[] args = joinPoint.getArgs();
-    String[] parameterNames = parameterNameDiscoverer.getParameterNames(method);
+    String[] paramNames = signature.getParameterNames();
 
-    if (parameterNames == null){
+    if (paramNames == null){
       throw new IllegalStateException("Parameter names must be available for AOP.");
     }
 
-    EvaluationContext context = new StandardEvaluationContext();
-    for (int i=0; i<parameterNames.length; ++i){
-      context.setVariable(parameterNames[i], args[i]);
+    Map<String, Object> argMap = new HashMap<>();
+    for (int i=0; i<paramNames.length; ++i){
+      argMap.put(paramNames[i], args[i]);
     }
 
-    Long userId = parser.parseExpression("#" + hasProfile.userIdArg())
-            .getValue(context, Long.class);
+    Long userId = (Long)argMap.get(hasProfile.userIdArg());
 
     boolean profileExists = profileRepository.existsByUserId(userId);
 


### PR DESCRIPTION
기존에는 MethodSignature에서 parameterNames를 가져온 후 SpEL로변환해  parameterNames와 argumentValues를 다루는 방법을 사용했음.
그러나 단순히 parameterNames와 argumentValues를 가져와 repository에 매개변수로 넘겨주기만 할거면 SpEL은 필요가 없음. (DTO로 넘겨받은 값을 추출하는 것엔 SpEL을 사용하는 점이 장점이 있다고 하나, 현재까지  구현한 aspect는 따로 추출이 필요한 parameter를 넘겨받고 있지 않음)
그래서 반환타입이나 메소드 이름 등의 정보를 포함하는 MethodSignature 대신 필요한 정보에만 접근하는 CodeSignature에서 parameterNames를 추출하는 것이 적절하다 생각했음.
이후 추출한 parameterNames와 argumentValues를 argMap이라는 hashmap에 넣고, aspect에서 필요한 값만 추출해서 로직 진행